### PR TITLE
[SE-810] Add token only when it's not blank

### DIFF
--- a/playback-sdk-android/src/main/java/com/streamamg/api/player/PlayBackAPIService.kt
+++ b/playback-sdk-android/src/main/java/com/streamamg/api/player/PlayBackAPIService.kt
@@ -48,7 +48,9 @@ internal class PlayBackAPIService(private val apiKey: String) : PlayBackAPI {
             try {
                 setRequestProperty("Accept", "application/json")
                 setRequestProperty("x-api-key", apiKey)
-                authorizationToken?.let { setRequestProperty("Authorization", "Bearer $it") }
+                if (!authorizationToken.isNullOrBlank()) {
+                    setRequestProperty("Authorization", "Bearer $authorizationToken")
+                }
 
                 val responseText = if (responseCode == HttpURLConnection.HTTP_OK) {
                     inputStream.bufferedReader().use(BufferedReader::readText)


### PR DESCRIPTION
### Jira
- related to https://pa-media-group.atlassian.net/browse/SE-810
### Changes
- added a check for the auth token to be added only when it's non-blank, because it doesn't make sense to send it as a broken `"Bearer   "` header in case an empty string or a whitespace is passed there by accident