### PR TITLE
[SE-810] Prevent using playerView when it isn't initialized

### DIFF
--- a/playback-sdk-android/src/main/java/com/streamamg/player/plugin/bitmovin/BitmovinVideoPlayerPlugin.kt
+++ b/playback-sdk-android/src/main/java/com/streamamg/player/plugin/bitmovin/BitmovinVideoPlayerPlugin.kt
@@ -67,15 +67,24 @@ class BitmovinVideoPlayerPlugin : VideoPlayerPlugin {
 
 
     override fun play() {
-        playerView.player?.play()
+        if (this::playerView
+                .isInitialized) {
+            playerView.player?.play()
+        }
     }
 
     override fun pause() {
-        playerView.player?.pause()
+        if (this::playerView
+                .isInitialized) {
+            playerView.player?.pause()
+        }
     }
 
     override fun removePlayer() {
-        playerView.player = null
+        if (this::playerView
+                .isInitialized) {
+            playerView.player = null
+        }
         ///playerView.player?.release
     }
 }


### PR DESCRIPTION
### Jira
- related to SDK integration ticket https://pa-media-group.atlassian.net/browse/SE-810
### Changes
- added checks if the `playerView` is already initialized before using it (otherwise it sometimes led to crashes)
### Concerns
Although this is a working solution, going forward we might need to refactor the place where `playerView` is initialized and/or held by the `BitmovinVideoPlayerPlugin` class as a lateinit variable.