### PR TITLE
[ZEUS-4778] Prevent crash caused by double unbinding of background service

### DIFF
--- a/playback-sdk-android/src/main/java/com/streamamg/player/plugin/bitmovin/BitmovinVideoPlayerPlugin.kt
+++ b/playback-sdk-android/src/main/java/com/streamamg/player/plugin/bitmovin/BitmovinVideoPlayerPlugin.kt
@@ -225,11 +225,16 @@ class BitmovinVideoPlayerPlugin : VideoPlayerPlugin {
 
     private fun bindAndStartBackgroundService(context: Context) {
         val intent = Intent(context, BackgroundPlaybackService::class.java)
-        if (BackgroundPlaybackService.isRunning) {
-            context.stopService(intent)
+
+        try {
+            if (BackgroundPlaybackService.isRunning) {
+                context.stopService(intent)
+            }
+            context.bindService(intent, mConnection, Context.BIND_AUTO_CREATE)
+            context.startService(intent)
+        } catch (e: Exception) {
+            e.printStackTrace()
         }
-        context.bindService(intent, mConnection, Context.BIND_AUTO_CREATE)
-        context.startService(intent)
     }
 
     private fun unbindAndStopBackgroundService(context: Context) {
@@ -237,9 +242,13 @@ class BitmovinVideoPlayerPlugin : VideoPlayerPlugin {
 
         val intent = Intent(context, BackgroundPlaybackService::class.java)
 
-        context.unbindService(mConnection)
-        context.stopService(intent)
-        isServiceBound = false
+        try {
+            context.unbindService(mConnection)
+            context.stopService(intent)
+            isServiceBound = false
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
     }
 
     /**


### PR DESCRIPTION
## Jira
- ZEUS-4778
## Changes
- added a simple flag to track if the service was already unbound and in that case prevent from doing it twice
- split the `backgroundService(start:)` method into two different methods with more meaningful names so it's easier to reason about what's going on
## Concerns
This is quick fix to patch the crash, which might be a symptom of a larger issue we have related to management of player and other related objects.