### PR TITLE
Feature/core 5015 android stoplight to include fullscreen configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ playerConfig.playbackConfig.backgroundPlaybackEnabled = true
 playerConfig.playbackConfig.fullscreenRotationEnabled = true
 ```
 // Apply playerConfig to your video player
-// videoPlayer.setConfig(playerConfig)
+// videoPlayer.setup(playerConfig)
 
 ## Loading Player UI
 

--- a/README.md
+++ b/README.md
@@ -138,9 +138,10 @@ val playerConfig = VideoPlayerConfig()
 playerConfig.playbackConfig.autoplayEnabled = true
 playerConfig.playbackConfig.backgroundPlaybackEnabled = true
 playerConfig.playbackConfig.fullscreenRotationEnabled = true
-```
+
 // Apply playerConfig to your video player
 videoPlayer.setup(playerConfig)
+```
 
 ## Loading Player UI
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ playerConfig.playbackConfig.backgroundPlaybackEnabled = true
 playerConfig.playbackConfig.fullscreenRotationEnabled = true
 ```
 // Apply playerConfig to your video player
-// videoPlayer.setup(playerConfig)
+videoPlayer.setup(playerConfig)
 
 ## Loading Player UI
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,31 @@ Example:
     }
 ```
 
+# Video Player Configuration
+
+This snippet demonstrates how to configure a video player using the `VideoPlayerConfig` object in Kotlin.
+
+## Configuration Options
+
+The provided example sets the following playback configurations:
+
+* **`autoplayEnabled = true`**: Enables automatic playback of the video when it is loaded.
+* **`backgroundPlaybackEnabled = true`**: Allows the video to continue playing even when the application is in the background.
+* **`fullscreenRotationEnabled = true`**: Enables automatic screen rotation when the video is in fullscreen mode. If set to `false`, the fullscreen button may be disabled or the fullscreen functionality will be restricted, preventing screen rotation.
+
+## Usage
+
+To utilize these configurations, create a `VideoPlayerConfig` instance and modify the desired properties within the `playbackConfig` object. Then, apply this configuration to your video player implementation.
+
+```kotlin
+val playerConfig = VideoPlayerConfig()
+playerConfig.playbackConfig.autoplayEnabled = true
+playerConfig.playbackConfig.backgroundPlaybackEnabled = true
+playerConfig.playbackConfig.fullscreenRotationEnabled = true
+```
+// Apply playerConfig to your video player
+// videoPlayer.setConfig(playerConfig)
+
 ## Loading Player UI
 
 To load the player UI in your application, use the `loadPlayer` method of the `PlaybackSDKManager` singleton object. This method is a Composable function that you can use to load and render the player UI.


### PR DESCRIPTION
Added instructions for the video payer config. Described logic about fullscreen config
Screenshot:
--------------------------------------------

<img width="901" alt="Screenshot 2025-02-27 at 10 29 48" src="https://github.com/user-attachments/assets/b033a660-2a59-4b9a-adde-301fb49dd8b6" />
